### PR TITLE
Fix pandas import paths and update quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,12 @@ cd project
 git clone https://github.com/abides-sim/abides.git
 cd abides
 pip install -r requirements.txt
+
+# run a sample configuration
+python -u abides.py -c rmsc01
 ```
+
+The simulation writes logs to a timestamped directory under `./log/`.
+You can visualize results using the analysis tools in `cli/`, e.g.
+`cli/ticker_plot.py`.
 

--- a/util/OrderBook.py
+++ b/util/OrderBook.py
@@ -9,7 +9,10 @@ from util.util import log_print, be_silent
 
 from copy import deepcopy
 import pandas as pd
-from pandas.io.json import json_normalize
+try:
+    from pandas import json_normalize
+except ImportError:  # pragma: no cover - fallback for older pandas
+    from pandas.io.json import json_normalize
 from functools import reduce
 from scipy.sparse import dok_matrix
 from tqdm import tqdm

--- a/util/formatting/convert_order_stream.py
+++ b/util/formatting/convert_order_stream.py
@@ -1,6 +1,9 @@
 import argparse
 import pandas as pd
-from pandas.io.json import json_normalize
+try:
+    from pandas import json_normalize
+except ImportError:  # pragma: no cover - fallback for older pandas
+    from pandas.io.json import json_normalize
 import json
 import os
 

--- a/util/simulation_run_stats.py
+++ b/util/simulation_run_stats.py
@@ -1,6 +1,9 @@
 import argparse
 import pandas as pd
-from pandas.io.json import json_normalize
+try:
+    from pandas import json_normalize
+except ImportError:  # pragma: no cover - fallback for older pandas
+    from pandas.io.json import json_normalize
 from glob import glob
 import re
 import os


### PR DESCRIPTION
## Summary
- handle `json_normalize` import for modern pandas
- add example run instructions in README

## Testing
- `pytest -q`
- `python -u abides.py -c rmsc01` *(fails: No module named 'numpy')*
- `pip install -q -r requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684eaf35b1bc83259d65c46e169cd82e