### PR TITLE
Fix random seed range for numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,12 @@ cd project
 git clone https://github.com/abides-sim/abides.git
 cd abides
 pip install -r requirements.txt
+
+# run a sample configuration
+python -u abides.py -c rmsc01
 ```
+
+The simulation writes logs to a timestamped directory under `./log/`.
+You can visualize results using the analysis tools in `cli/`, e.g.
+`cli/ticker_plot.py`.
 

--- a/config/execution.py
+++ b/config/execution.py
@@ -105,7 +105,7 @@ symbols = {symbol: {'r_bar': r_bar,
                     'megashock_lambda_a': 2.77778e-18,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32))}}
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))}}
 
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -115,7 +115,7 @@ oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 symbols = {
     symbol: {
         'fundamental_file_path': args.fundamental_file_path,
-        'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32))
+        'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
     }
 }
 oracle = ExternalFileOracle(symbols)
@@ -140,7 +140,7 @@ agents.extend([ExchangeAgent(id=0,
                              stream_history=stream_history_length,
                              book_freq=0,
                              wide_book=True,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -156,7 +156,7 @@ agents.extend([NoiseAgent(id=j,
                           wakeup_time=util.get_wake_time(noise_mkt_open, noise_mkt_close),
                           log_orders=False,
                           log_to_file=False,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -174,7 +174,7 @@ agents.extend([ValueAgent(id=j,
                           lambda_a=7e-11,
                           log_orders=False,
                           log_to_file=False,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -212,7 +212,7 @@ agents.extend([AdaptiveMarketMakerAgent(id=j,
                                         spread_alpha=0.75,
                                         backstop_quantity=50000,
                                         log_orders=True,
-                                        random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                                        random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
                for idx, j in enumerate(range(agent_count, agent_count + num_mm_agents))])
 agent_count += num_mm_agents
 agent_types.extend('AdaptiveMarketMakerAgent')
@@ -228,7 +228,7 @@ agents.extend([MomentumAgent(id=j,
                              max_size=10,
                              wake_up_freq='20s',
                              log_orders=True,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_count += num_momentum_agents
 agent_types.extend("MomentumAgent")
@@ -255,7 +255,7 @@ twap_agent = TWAPExecutionAgent(id=agent_count,
                                 freq=execution_frequency,
                                 trade=trade,
                                 log_orders=True,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
 execution_agents = [twap_agent]
 
 """
@@ -271,7 +271,7 @@ vwap_agent = VWAPExecutionAgent(id=agent_count,
                                 volume_profile_path=None,
                                 trade=trade,
                                 log_orders=True,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
 execution_agents = [vwap_agent]
 
 pov_agent = POVExecutionAgent(id=agent_count,
@@ -288,7 +288,7 @@ pov_agent = POVExecutionAgent(id=agent_count,
                               quantity=execution_quantity,
                               trade=trade,
                               log_orders=True,
-                              random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+                              random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
 execution_agents = [pov_agent]
 """
 
@@ -299,7 +299,7 @@ agent_count += 1
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32)))
+kernel = Kernel("Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max)))
 
 kernelStartTime = historical_date
 kernelStopTime = mkt_close + pd.to_timedelta('00:01:00')
@@ -307,7 +307,7 @@ kernelStopTime = mkt_close + pd.to_timedelta('00:01:00')
 defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/exp_agent_demo.py
+++ b/config/exp_agent_demo.py
@@ -136,7 +136,7 @@ symbols = {symbol: {'r_bar': r_bar,
                     'megashock_lambda_a': 2.77778e-18,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))}}
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))}}
 
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -158,7 +158,7 @@ agents.extend([ExchangeAgent(id=0,
                              stream_history=stream_history_length,
                              book_freq=book_freq,
                              wide_book=True,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -174,7 +174,7 @@ agents.extend([NoiseAgent(id=j,
                           starting_cash=starting_cash,
                           wakeup_time=util.get_wake_time(noise_mkt_open, noise_mkt_close),
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -191,7 +191,7 @@ agents.extend([ValueAgent(id=j,
                           kappa=kappa,
                           lambda_a=lambda_a,
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -231,7 +231,7 @@ agents.extend([AdaptiveMarketMakerAgent(id=j,
                                 spread_alpha=0.75,
                                 backstop_quantity=50000,
                                 log_orders=log_orders,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for idx, j in enumerate(range(agent_count, agent_count + num_mm_agents))])
 agent_count += num_mm_agents
@@ -250,7 +250,7 @@ agents.extend([MomentumAgent(id=j,
                              max_size=10,
                              wake_up_freq='20s',
                              log_orders=log_orders,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_count += num_momentum_agents
@@ -274,7 +274,7 @@ if args.experimental_agent:
         short_window=args.ea_short_window,
         long_window=args.ea_long_window,
         log_orders=True,
-        random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))
+        random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))
     )
 else:
     experimental_agent = ExampleExperimentalAgentTemplate(
@@ -286,7 +286,7 @@ else:
         levels=5,
         subscription_freq=1e9,
         log_orders=True,
-        random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))
+        random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))
     )
 
 experimental_agents = [experimental_agent]
@@ -298,7 +298,7 @@ agent_count += 1
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("RMSC03 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("RMSC03 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -308,7 +308,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/hist_fund_diverse.py
+++ b/config/hist_fund_diverse.py
@@ -92,7 +92,7 @@ starting_cash = 10000000  # Cash in this simulator is always in CENTS.
 symbols = {
     symbol : {
         'fundamental_file_path': args.fundamental_file_path,
-        'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))
+        'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))
     }
 }
 oracle = ExternalFileOracle(symbols)
@@ -114,7 +114,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq=book_freq,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -127,7 +127,7 @@ agents.extend([NoiseAgent(id=j,
                           starting_cash=starting_cash,
                           wakeup_time=util.get_wake_time(mkt_open, mkt_close),
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -143,7 +143,7 @@ agents.extend([ValueAgent(id=j,
                           r_bar=r_bar,
                           kappa=kappa,
                           lambda_a=lambda_a,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -159,7 +159,7 @@ agents.extend([MarketMakerAgent(id=j,
                                 max_size=101,
                                 wake_up_freq="1min",
                                 log_orders=log_orders,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for j in range(agent_count, agent_count + num_mm_agents)])
 agent_count += num_mm_agents
@@ -176,7 +176,7 @@ agents.extend([MomentumAgent(id=j,
                              min_size=1,
                              max_size=10,
                              log_orders=log_orders,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_count += num_momentum_agents
@@ -185,7 +185,7 @@ agent_types.extend("MomentumAgent")
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("hist_fund_diverse Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("hist_fund_diverse Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -195,7 +195,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/hist_fund_value.py
+++ b/config/hist_fund_value.py
@@ -90,7 +90,7 @@ starting_cash = 10000000  # Cash in this simulator is always in CENTS.
 symbols = {
     symbol : {
         'fundamental_file_path': args.fundamental_file_path,
-        'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))
+        'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))
     }
 }
 oracle = ExternalFileOracle(symbols)
@@ -112,7 +112,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq=book_freq,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -125,7 +125,7 @@ agents.extend([NoiseAgent(id=j,
                           starting_cash=starting_cash,
                           wakeup_time=util.get_wake_time(mkt_open, mkt_close),
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -141,7 +141,7 @@ agents.extend([ValueAgent(id=j,
                           r_bar=r_bar,
                           kappa=kappa,
                           lambda_a=lambda_a,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -149,7 +149,7 @@ agent_types.extend(['ValueAgent'])
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("hist_fund_diverse Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("hist_fund_diverse Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -159,7 +159,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/impact.py
+++ b/config/impact.py
@@ -147,7 +147,7 @@ symbols = { 'IBM' : { 'r_bar' : 100000, 'kappa' : 0.05, 'sigma_s' : sigma_s } }
 
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
 
 
 
@@ -174,7 +174,7 @@ oracle = MeanRevertingOracle(mkt_open, mkt_close, symbols)
 
 # Create the exchange.
 num_exchanges = 1
-agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
                 for j in range(agent_count, agent_count + num_exchanges) ])
 agent_types.extend(["ExchangeAgent" for j in range(num_exchanges)])
 agent_count += num_exchanges
@@ -253,14 +253,14 @@ hbl = [ (75, 250, 500, 1, 2), (75, 250, 500, 1, 3), (75, 250, 500, 1, 5), (75, 2
 # ZI strategy split.
 for i,x in enumerate(zi):
   strat_name = "Type {} [{} <= R <= {}, eta={}]".format(i+1, x[1], x[2], x[3])
-  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['kappa'], sigma_s=s['sigma_s'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['kappa'], sigma_s=s['sigma_s'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "ZeroIntelligenceAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
 # HBL strategy split.
 for i,x in enumerate(hbl):
   strat_name = "Type {} [{} <= R <= {}, eta={}, L={}]".format(i+1, x[1], x[2], x[3], x[4])
-  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)), log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['kappa'], sigma_s=s['sigma_s'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)), log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['kappa'], sigma_s=s['sigma_s'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "HeuristicBeliefLearningAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
@@ -272,7 +272,7 @@ for i,x in enumerate(hbl):
 impact_time = midnight + pd.to_timedelta('09:30:00.0000002')
 
 i = agent_count
-agents.append(ImpactAgent(i, "Impact Agent {}".format(i), "ImpactAgent", symbol = "IBM", starting_cash = starting_cash, greed = greed, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+agents.append(ImpactAgent(i, "Impact Agent {}".format(i), "ImpactAgent", symbol = "IBM", starting_cash = starting_cash, greed = greed, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
 agent_types.append("Impact Agent {}".format(i))
 agent_count += 1
 

--- a/config/loop_obi.py
+++ b/config/loop_obi.py
@@ -21,7 +21,7 @@ from math import ceil, floor
 ###### that would otherwise have been repeated many times.                    ######
 
 def get_rand_obj(seed_obj):
-  return np.random.RandomState(seed = seed_obj.randint(low = 0, high = 2**32))
+  return np.random.RandomState(seed = seed_obj.randint(low = 0, high = np.iinfo(np.int32).max))
 
 
 ###### Wallclock tracking for overall experimental scheduling to CPUs.
@@ -276,12 +276,12 @@ print ("Configuration seed: {}\n".format(seed))
 ### seed for each simulation, but the entire experiment will still be deterministic
 ### given the same initial (global) seed.
 
-kernel_seeds = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+kernel_seeds = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
 symbol_seeds = {}
-for sym in symbols:  symbol_seeds[sym] = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+for sym in symbols:  symbol_seeds[sym] = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
-agent_seeds = [ np.random.RandomState(seed=np.random.randint(low=0,high=2**32)) ] * num_agents
+agent_seeds = [ np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)) ] * num_agents
 
 
 

--- a/config/marketreplay.py
+++ b/config/marketreplay.py
@@ -92,7 +92,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq='all',
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
@@ -112,7 +112,7 @@ agents.extend([MarketReplayAgent(id=1,
                                  orders_file_path=orders_file_path,
                                  processed_orders_folder_path='/efs/data/marketreplay/',
                                  starting_cash=0,
-                                 random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                 random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                            dtype='uint64')))])
 agent_types.extend("MarketReplayAgent")
 agent_count += 1
@@ -120,7 +120,7 @@ agent_count += 1
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("Market Replay Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("Market Replay Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date_pd

--- a/config/obi_rmsc02.py
+++ b/config/obi_rmsc02.py
@@ -100,7 +100,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq='all',
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
@@ -116,7 +116,7 @@ agents.extend([MarketMakerAgent(id=j,
                                 max_size=1000,
                                 subscribe=True,
                                 log_orders=False,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for j in range(agent_count, agent_count + num_mm_agents)])
 
@@ -132,7 +132,7 @@ symbols = {symbol: {'r_bar': 1e5,
                     'megashock_lambda_a': 2.77778e-13,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                  dtype='uint64'))}}
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -153,7 +153,7 @@ agents.extend([ZeroIntelligenceAgent(id=j,
                                      eta=1,
                                      lambda_a=1e-12,
                                      log_orders=False,
-                                     random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                     random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                dtype='uint64')))
                for j in range(agent_count, agent_count + num_zi_agents)])
 agent_types.extend("ZeroIntelligenceAgent")
@@ -167,7 +167,7 @@ agents.extend([OrderBookImbalanceAgent(id=j,
                                        symbol=symbol,
                                        starting_cash=starting_cash,
                                        log_orders=False,
-                                       random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                       random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                  dtype='uint64')))
                for j in range(agent_count, agent_count + num_obi_agents)])
 agent_types.extend("OrderBookImbalanceAgent")
@@ -184,7 +184,7 @@ agents.extend([MomentumAgent(id=j,
                              max_size=10,
                              subscribe=True,
                              log_orders=False,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_types.extend("MomentumAgent")
@@ -200,7 +200,7 @@ agents.extend([SubscriptionAgent(id=agent_count,
                                  levels=5,
                                  freq=10e9,
                                  log_orders=False,
-                                 random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                 random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                            dtype='uint64')))])
 agent_types.extend("SubscriptionAgent")
 agent_count += 1
@@ -222,14 +222,14 @@ if args.agent_name:
                              max_size=10,
                              log_orders=False,
                              random_state=np.random.RandomState(
-                                 seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                                 seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
     agent_count += 1
     agent_types.extend('AgentUnderTest')
 
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("Market Replay Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("Market Replay Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date

--- a/config/ppfl_icaif20.py
+++ b/config/ppfl_icaif20.py
@@ -131,13 +131,13 @@ defaultComputationDelay = 1000000000 * 5   # five seconds
 
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
 
 ### Obtain random state for whatever latency model will be used.
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
 ### Obtain a seed for the train-test split shuffling.
-shuffle_seed = np.random.randint(low=0,high=2**32)
+shuffle_seed = np.random.randint(low=0,high=np.iinfo(np.int32).max)
 
 ### Configure the agents.  When conducting "agent of change" experiments, the
 ### new agents should be added at the END only.
@@ -181,7 +181,7 @@ X_train, X_test, y_train, y_test = train_test_split(X_data, y_data, test_size=0.
 ### Configure a service agent.
 
 agents.extend([ PPFL_ServiceAgent(0, "PPFL Service Agent 0", "PPFL_ServiceAgent",
-                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),
+                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),
                 msg_fwd_delay=0, iterations = num_iterations, num_clients = num_clients) ])
 agent_types.extend(["PPFL_ServiceAgent"])
 agent_count += 1
@@ -215,7 +215,7 @@ for i in range (a, b):
                 clear_learning = clear_learning, num_clients = num_clients, num_subgraphs = num_subgraphs,
                 multiplier = accy_multiplier, X_train = X_train, y_train = y_train, X_test = X_test, y_test = y_test,
                 split_size = split_size, secret_scale = secret_scale, collusion = collusion,
-                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
 
 agent_types.extend([ "PPFL_ClientAgent" for i in range(a,b) ])
 agent_count += num_clients

--- a/config/ppfl_template.py
+++ b/config/ppfl_template.py
@@ -131,10 +131,10 @@ defaultComputationDelay = 1000000000 * 5   # five seconds
 
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
 
 ### Obtain random state for whatever latency model will be used.
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
 ### Configure the agents.  When conducting "agent of change" experiments, the
 ### new agents should be added at the END only.
@@ -188,7 +188,7 @@ X_train, X_test, y_train, y_test = train_test_split(X_data, y_data, test_size=0.
 ### Configure a service agent.
 
 agents.extend([ PPFL_ServiceAgent(0, "PPFL Service Agent 0", "PPFL_ServiceAgent",
-                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),
+                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),
                 msg_fwd_delay=0, iterations = num_iterations, num_clients = num_clients) ])
 agent_types.extend(["PPFL_ServiceAgent"])
 agent_count += 1
@@ -221,7 +221,7 @@ for i in range (a, b):
                 num_clients = num_clients, num_subgraphs = num_subgraphs,
                 multiplier = accy_multiplier, X_train = X_train, y_train = y_train, X_test = X_test, y_test = y_test,
                 split_size = split_size, secret_scale = secret_scale,
-                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
 
 agent_types.extend([ "PPFL_ClientAgent" for i in range(a,b) ])
 agent_count += num_clients

--- a/config/qlearning.py
+++ b/config/qlearning.py
@@ -17,7 +17,7 @@ from math import ceil, floor
 ###### that would otherwise have been repeated many times.                    ######
 
 def get_rand_obj(seed_obj):
-  return np.random.RandomState(seed = seed_obj.randint(low = 0, high = 2**32))
+  return np.random.RandomState(seed = seed_obj.randint(low = 0, high = np.iinfo(np.int32).max))
 
 
 ###### One-time configuration section.  This section sets up definitions that ######
@@ -209,12 +209,12 @@ print ("Configuration seed: {}\n".format(seed))
 ### seed for each simulation, but the entire experiment will still be deterministic
 ### given the same initial (global) seed.
 
-kernel_seeds = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+kernel_seeds = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
 symbol_seeds = {}
-for sym in symbols:  symbol_seeds[sym] = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+for sym in symbols:  symbol_seeds[sym] = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
-agent_seeds = [ np.random.RandomState(seed=np.random.randint(low=0,high=2**32)) ] * num_agents
+agent_seeds = [ np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)) ] * num_agents
 
 
 

--- a/config/random_fund_diverse.py
+++ b/config/random_fund_diverse.py
@@ -98,7 +98,7 @@ symbols = {symbol: {'r_bar': r_bar,
                     'megashock_lambda_a': 2.77778e-13,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))}}
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))}}
 
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -114,7 +114,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq=book_freq,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -127,7 +127,7 @@ agents.extend([NoiseAgent(id=j,
                           starting_cash=starting_cash,
                           wakeup_time=util.get_wake_time(mkt_open, mkt_close),
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -143,7 +143,7 @@ agents.extend([ValueAgent(id=j,
                           r_bar=r_bar,
                           kappa=kappa,
                           lambda_a=lambda_a,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -159,7 +159,7 @@ agents.extend([MarketMakerAgent(id=j,
                                 max_size=101,
                                 wake_up_freq="1min",
                                 log_orders=log_orders,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for j in range(agent_count, agent_count + num_mm_agents)])
 agent_count += num_mm_agents
@@ -176,7 +176,7 @@ agents.extend([MomentumAgent(id=j,
                              min_size=1,
                              max_size=10,
                              log_orders=log_orders,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_count += num_momentum_agents
@@ -185,7 +185,7 @@ agent_types.extend("MomentumAgent")
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("random_fund_diverse Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("random_fund_diverse Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -195,7 +195,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/random_fund_value.py
+++ b/config/random_fund_value.py
@@ -96,7 +96,7 @@ symbols = {symbol: {'r_bar': r_bar,
                     'megashock_lambda_a': 2.77778e-13,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))}}
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))}}
 
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -112,7 +112,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq=book_freq,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -125,7 +125,7 @@ agents.extend([NoiseAgent(id=j,
                           starting_cash=starting_cash,
                           wakeup_time=util.get_wake_time(mkt_open, mkt_close),
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -141,7 +141,7 @@ agents.extend([ValueAgent(id=j,
                           r_bar=r_bar,
                           kappa=kappa,
                           lambda_a=lambda_a,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -149,7 +149,7 @@ agent_types.extend(['ValueAgent'])
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("random_fund_value Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("random_fund_value Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -159,7 +159,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/rmsc01.py
+++ b/config/rmsc01.py
@@ -99,7 +99,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq=0,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
@@ -114,7 +114,7 @@ agents.extend([MarketMakerAgent(id=j,
                                 min_size=500,
                                 max_size=1000,
                                 log_orders=False,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for j in range(agent_count, agent_count + num_mm_agents)])
 
@@ -130,7 +130,7 @@ symbols = {symbol: {'r_bar': 1e5,
                     'megashock_lambda_a': 2.77778e-13,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                  dtype='uint64'))}}
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -151,7 +151,7 @@ agents.extend([ZeroIntelligenceAgent(id=j,
                                      eta=1,
                                      lambda_a=1e-12,
                                      log_orders=False,
-                                     random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                     random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                dtype='uint64')))
                for j in range(agent_count, agent_count + num_zi_agents)])
 agent_types.extend("ZeroIntelligenceAgent")
@@ -176,7 +176,7 @@ agents.extend([HeuristicBeliefLearningAgent(id=j,
                                             lambda_a=1e-12,
                                             L=2,
                                             log_orders=False,
-                                            random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                            random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                       dtype='uint64')))
                for j in range(agent_count, agent_count + num_hbl_agents)])
 agent_types.extend("HeuristicBeliefLearningAgent")
@@ -192,7 +192,7 @@ agents.extend([MomentumAgent(id=j,
                              min_size=1,
                              max_size=10,
                              log_orders=False,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_types.extend("MomentumAgent")
@@ -214,13 +214,13 @@ if args.agent_name:
                         min_size=1, 
                         max_size=10, 
                         log_orders=False, 
-                        random_state=np.random.RandomState(seed=np.random.randint(low=0,high=2**32,dtype='uint64')))])
+                        random_state=np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max,dtype='uint64')))])
     agent_count += 1
 
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("RMSC01 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("RMSC01 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -230,7 +230,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/rmsc02.py
+++ b/config/rmsc02.py
@@ -99,7 +99,7 @@ agents.extend([ExchangeAgent(id=0,
                              computation_delay=0,
                              stream_history=10,
                              book_freq=0,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
@@ -115,7 +115,7 @@ agents.extend([MarketMakerAgent(id=j,
                                 max_size=1000,
                                 subscribe=True,
                                 log_orders=False,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for j in range(agent_count, agent_count + num_mm_agents)])
 
@@ -131,7 +131,7 @@ symbols = {symbol: {'r_bar': 1e5,
                     'megashock_lambda_a': 2.77778e-13,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                  dtype='uint64'))}}
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -152,7 +152,7 @@ agents.extend([ZeroIntelligenceAgent(id=j,
                                      eta=1,
                                      lambda_a=1e-12,
                                      log_orders=False,
-                                     random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                     random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                dtype='uint64')))
                for j in range(agent_count, agent_count + num_zi_agents)])
 agent_types.extend("ZeroIntelligenceAgent")
@@ -178,7 +178,7 @@ agents.extend([HeuristicBeliefLearningAgent(id=j,
                                             L=2,
                                             log_orders=False,
                                             random_state=np.random.RandomState(
-                                                seed=np.random.randint(low=0, high=2 ** 32,
+                                                seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_hbl_agents)])
 agent_types.extend("HeuristicBeliefLearningAgent")
@@ -195,7 +195,7 @@ agents.extend([MomentumAgent(id=j,
                              max_size=10,
                              subscribe=True,
                              log_orders=False,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_types.extend("MomentumAgent")
@@ -211,7 +211,7 @@ agents.extend([SubscriptionAgent(id=agent_count,
                                  levels=5,
                                  freq=10e9,
                                  log_orders=False,
-                                 random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                 random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                            dtype='uint64')))])
 agent_types.extend("SubscriptionAgent")
 agent_count += 1
@@ -233,14 +233,14 @@ if args.agent_name:
                              max_size=10,
                              log_orders=False,
                              random_state=np.random.RandomState(
-                                 seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                                 seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
     agent_count += 1
     agent_types.extend('AgentUnderTest')
 
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("RMSC02 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("RMSC02 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -250,7 +250,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/rmsc03.py
+++ b/config/rmsc03.py
@@ -169,7 +169,7 @@ symbols = {symbol: {'r_bar': r_bar,
                     'megashock_lambda_a': 2.77778e-18,
                     'megashock_mean': 1e3,
                     'megashock_var': 5e4,
-                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))}}
+                    'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))}}
 
 oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
@@ -191,7 +191,7 @@ agents.extend([ExchangeAgent(id=0,
                              stream_history=stream_history_length,
                              book_freq=book_freq,
                              wide_book=True,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))])
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))])
 agent_types.extend("ExchangeAgent")
 agent_count += 1
 
@@ -207,7 +207,7 @@ agents.extend([NoiseAgent(id=j,
                           starting_cash=starting_cash,
                           wakeup_time=util.get_wake_time(noise_mkt_open, noise_mkt_close),
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_noise)])
 agent_count += num_noise
 agent_types.extend(['NoiseAgent'])
@@ -224,7 +224,7 @@ agents.extend([ValueAgent(id=j,
                           kappa=kappa,
                           lambda_a=lambda_a,
                           log_orders=log_orders,
-                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                          random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_value)])
 agent_count += num_value
 agent_types.extend(['ValueAgent'])
@@ -264,7 +264,7 @@ agents.extend([AdaptiveMarketMakerAgent(id=j,
                                 spread_alpha=args.mm_spread_alpha,
                                 backstop_quantity=args.mm_backstop_quantity,
                                 log_orders=log_orders,
-                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
                for idx, j in enumerate(range(agent_count, agent_count + num_mm_agents))])
 agent_count += num_mm_agents
@@ -283,7 +283,7 @@ agents.extend([MomentumAgent(id=j,
                              max_size=10,
                              wake_up_freq='20s',
                              log_orders=log_orders,
-                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                             random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                        dtype='uint64')))
                for j in range(agent_count, agent_count + num_momentum_agents)])
 agent_count += num_momentum_agents
@@ -316,7 +316,7 @@ pov_agent = POVExecutionAgent(id=agent_count,
                               quantity=pov_quantity,
                               trade=trade,
                               log_orders=True,  # needed for plots so conflicts with others
-                              random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+                              random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                           dtype='uint64')))
 
 execution_agents = [pov_agent]
@@ -328,7 +328,7 @@ agent_count += 1
 ########################################################################################################################
 ########################################### KERNEL AND OTHER CONFIG ####################################################
 
-kernel = Kernel("RMSC03 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32,
+kernel = Kernel("RMSC03 Kernel", random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max,
                                                                                                   dtype='uint64')))
 
 kernelStartTime = historical_date
@@ -338,7 +338,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC

--- a/config/sparse_zi_100.py
+++ b/config/sparse_zi_100.py
@@ -127,14 +127,14 @@ defaultComputationDelay = 1000000000        # one second
 
 # Note: sigma_s is no longer used by the agents or the fundamental (for sparse discrete simulation).
 
-symbols = { 'JPM' : { 'r_bar' : 1e5, 'kappa' : 1.67e-12, 'agent_kappa' : 1.67e-15, 'sigma_s' : 0, 'fund_vol' : 1e-8, 'megashock_lambda_a' : 2.77778e-13, 'megashock_mean' : 1e3, 'megashock_var' : 5e4, 'random_state' : np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')) } }
+symbols = { 'JPM' : { 'r_bar' : 1e5, 'kappa' : 1.67e-12, 'agent_kappa' : 1.67e-15, 'sigma_s' : 0, 'fund_vol' : 1e-8, 'megashock_lambda_a' : 2.77778e-13, 'megashock_mean' : 1e3, 'megashock_var' : 5e4, 'random_state' : np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')) } }
  
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')))
 
 ### Obtain random state for whatever latency model will be used.
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))
 
 
 
@@ -161,7 +161,7 @@ oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
 # Create the exchange.
 num_exchanges = 1
-agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')))
+agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')))
                 for j in range(agent_count, agent_count + num_exchanges) ])
 agent_types.extend(["ExchangeAgent" for j in range(num_exchanges)])
 agent_count += num_exchanges
@@ -189,7 +189,7 @@ zi = [ (15, 0, 250, 1), (15, 0, 500, 1), (14, 0, 1000, 0.8), (14, 0, 1000, 1), (
 # minutes.
 for i,x in enumerate(zi):
   strat_name = "Type {} [{} <= R <= {}, eta={}]".format(i+1, x[1], x[2], x[3])
-  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')),log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['agent_kappa'], sigma_s=s['fund_vol'], q_max=10, sigma_pv=5e6, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=1e-12) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')),log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['agent_kappa'], sigma_s=s['fund_vol'], q_max=10, sigma_pv=5e6, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=1e-12) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "ZeroIntelligenceAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 

--- a/config/sparse_zi_1000.py
+++ b/config/sparse_zi_1000.py
@@ -126,11 +126,11 @@ defaultComputationDelay = 1000000000        # one second
 
 # Note: sigma_s is no longer used by the agents or the fundamental (for sparse discrete simulation).
 
-symbols = { 'JPM' : { 'r_bar' : 1e5, 'kappa' : 1.67e-12, 'agent_kappa' : 1.67e-15, 'sigma_s' : 0, 'fund_vol' : 1e-8, 'megashock_lambda_a' : 2.77778e-13, 'megashock_mean' : 1e3, 'megashock_var' : 5e4, 'random_state' : np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')) } }
+symbols = { 'JPM' : { 'r_bar' : 1e5, 'kappa' : 1.67e-12, 'agent_kappa' : 1.67e-15, 'sigma_s' : 0, 'fund_vol' : 1e-8, 'megashock_lambda_a' : 2.77778e-13, 'megashock_mean' : 1e3, 'megashock_var' : 5e4, 'random_state' : np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')) } }
  
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')))
 
 
 
@@ -157,7 +157,7 @@ oracle = SparseMeanRevertingOracle(mkt_open, mkt_close, symbols)
 
 # Create the exchange.
 num_exchanges = 1
-agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')))
+agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')))
                 for j in range(agent_count, agent_count + num_exchanges) ])
 agent_types.extend(["ExchangeAgent" for j in range(num_exchanges)])
 agent_count += num_exchanges
@@ -185,7 +185,7 @@ zi = [ (143, 0, 250, 1), (143, 0, 500, 1), (143, 0, 1000, 0.8), (143, 0, 1000, 1
 # minutes.
 for i,x in enumerate(zi):
   strat_name = "Type {} [{} <= R <= {}, eta={}]".format(i+1, x[1], x[2], x[3])
-  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32, dtype='uint64')),log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['agent_kappa'], sigma_s=s['fund_vol'], q_max=10, sigma_pv=5e6, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=1e-12) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max, dtype='uint64')),log_orders=log_orders, symbol=symbol, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['agent_kappa'], sigma_s=s['fund_vol'], q_max=10, sigma_pv=5e6, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=1e-12) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "ZeroIntelligenceAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 

--- a/config/sum.py
+++ b/config/sum.py
@@ -89,7 +89,7 @@ defaultComputationDelay = 1000000000 * 5   # five seconds
 
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
 
 
 ### Configure the agents.  When conducting "agent of change" experiments, the
@@ -106,7 +106,7 @@ num_clients = 10
 ### Configure a sum service agent.
 
 agents.extend([ SumServiceAgent(0, "Sum Service Agent 0", "SumServiceAgent",
-                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),
+                random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),
                 num_clients = num_clients) ])
 agent_types.extend(["SumServiceAgent"])
 agent_count += 1
@@ -116,7 +116,7 @@ agent_count += 1
 ### Configure a population of sum client agents.
 a, b = agent_count, agent_count + num_clients
 
-agents.extend([ SumClientAgent(i, "Sum Client Agent {}".format(i), "SumClientAgent", peer_list = [ x for x in range(a,b) if x != i ], random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))) for i in range(a,b) ])
+agents.extend([ SumClientAgent(i, "Sum Client Agent {}".format(i), "SumClientAgent", peer_list = [ x for x in range(a,b) if x != i ], random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))) for i in range(a,b) ])
 agent_types.extend([ "SumClientAgent" for i in range(a,b) ])
 agent_count += num_clients
 

--- a/config/twoSymbols.py
+++ b/config/twoSymbols.py
@@ -150,11 +150,11 @@ symbols = { 'SYM1' : { 'r_bar' : 100000, 'kappa' : 0.05, 'sigma_s' : sigma_s }, 
 #symbols = { 'IBM' : { 'r_bar' : 100000, 'kappa' : 0.05, 'sigma_s' : sigma_s }, 'GOOG' : { 'r_bar' : 150000, 'kappa' : 0.05, 'sigma_s' : sigma_s } }
 symbols_full = symbols.copy()
 
-#seed=np.random.randint(low=0,high=2**32)
+#seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)
 #seed = 2000
 
 ### Configure the Kernel.
-kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+kernel = Kernel("Base Kernel", random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
 
 
 
@@ -182,7 +182,7 @@ oracle = MeanRevertingOracle(mkt_open, mkt_close, symbols)
 
 # Create the exchange.
 num_exchanges = 1
-agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols_full], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+agents.extend([ ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close, [s for s in symbols_full], log_orders=log_orders, book_freq=book_freq, pipeline_delay = 0, computation_delay = 0, stream_history = 10, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
                 for j in range(agent_count, agent_count + num_exchanges) ])
 agent_types.extend(["ExchangeAgent" for j in range(num_exchanges)])
 agent_count += num_exchanges
@@ -196,7 +196,7 @@ prime_close = midnight + pd.to_timedelta('17:00:01')
 
 # Create the primary.
 num_primes = 1
-agents.extend([ EtfPrimaryAgent(j, "ETF Primary Agent {}".format(j), "EtfPrimaryAgent", prime_open, prime_close, 'ETF', pipeline_delay = 0, computation_delay = 0, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)))
+agents.extend([ EtfPrimaryAgent(j, "ETF Primary Agent {}".format(j), "EtfPrimaryAgent", prime_open, prime_close, 'ETF', pipeline_delay = 0, computation_delay = 0, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)))
                 for j in range(agent_count, agent_count + num_primes) ])
 agent_types.extend(["EtfPrimeAgent" for j in range(num_primes)])
 agent_count += num_primes
@@ -279,19 +279,19 @@ hbl = [ (75, 250, 500, 1, 2), (75, 250, 500, 1, 3), (75, 250, 500, 1, 5), (75, 2
 # ZI strategy split.
 for i,x in enumerate(zi):
   strat_name = "Type {} [{} <= R <= {}, eta={}]".format(i+1, x[1], x[2], x[3])
-  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),log_orders=log_orders, symbol=symbol1, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s1['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),log_orders=log_orders, symbol=symbol1, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s1['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "ZeroIntelligenceAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
 for i,x in enumerate(zi):
   strat_name = "Type {} [{} <= R <= {}, eta={}]".format(i+1, x[1], x[2], x[3])
-  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),log_orders=log_orders, symbol=symbol2, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s2['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),log_orders=log_orders, symbol=symbol2, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s2['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "ZeroIntelligenceAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
     
 for i,x in enumerate(zi):
   strat_name = "Type {} [{} <= R <= {}, eta={}]".format(i+1, x[1], x[2], x[3])
-  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)),log_orders=log_orders, symbol=symbol3, starting_cash=starting_cash, sigma_n=sigma_n, portfolio = {'SYM1':s1['r_bar'], 'SYM2': s2['r_bar']}, q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ ZeroIntelligenceAgent(j, "ZI Agent {} {}".format(j, strat_name), "ZeroIntelligenceAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)),log_orders=log_orders, symbol=symbol3, starting_cash=starting_cash, sigma_n=sigma_n, portfolio = {'SYM1':s1['r_bar'], 'SYM2': s2['r_bar']}, q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "ZeroIntelligenceAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
@@ -299,19 +299,19 @@ for i,x in enumerate(zi):
 # HBL strategy split.
 for i,x in enumerate(hbl):
   strat_name = "Type {} [{} <= R <= {}, eta={}, L={}]".format(i+1, x[1], x[2], x[3], x[4])
-  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)), log_orders=log_orders, symbol=symbol1, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s1['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)), log_orders=log_orders, symbol=symbol1, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s1['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "HeuristicBeliefLearningAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
 for i,x in enumerate(hbl):
   strat_name = "Type {} [{} <= R <= {}, eta={}, L={}]".format(i+1, x[1], x[2], x[3], x[4])
-  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)), log_orders=log_orders, symbol=symbol2, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s2['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)), log_orders=log_orders, symbol=symbol2, starting_cash=starting_cash, sigma_n=sigma_n, r_bar=s2['r_bar'], q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "HeuristicBeliefLearningAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
 for i,x in enumerate(hbl):
   strat_name = "Type {} [{} <= R <= {}, eta={}, L={}]".format(i+1, x[1], x[2], x[3], x[4])
-  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)), log_orders=log_orders, symbol=symbol3, starting_cash=starting_cash, sigma_n=sigma_n, portfolio = {'SYM1':s1['r_bar'], 'SYM2': s2['r_bar']}, q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ HeuristicBeliefLearningAgent(j, "HBL Agent {} {}".format(j, strat_name), "HeuristicBeliefLearningAgent {}".format(strat_name), random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)), log_orders=log_orders, symbol=symbol3, starting_cash=starting_cash, sigma_n=sigma_n, portfolio = {'SYM1':s1['r_bar'], 'SYM2': s2['r_bar']}, q_max=10, sigma_pv=5000000, R_min=x[1], R_max=x[2], eta=x[3], lambda_a=0.005, L=x[4]) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "HeuristicBeliefLearningAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
     
@@ -320,7 +320,7 @@ i = agent_count
 lookback = 10
 num_tf = 20
 for j in range(num_tf):
-  agents.append(MomentumAgent(i, "Momentum Agent {}".format(i), symbol=symbol1, starting_cash = starting_cash, lookback=lookback, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32)), log_orders = log_orders))
+  agents.append(MomentumAgent(i, "Momentum Agent {}".format(i), symbol=symbol1, starting_cash = starting_cash, lookback=lookback, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max)), log_orders = log_orders))
   agent_types.append("MomentumAgent {}".format(i))
   i+=1
 agent_count += num_tf
@@ -342,7 +342,7 @@ i = agent_count
 gamma = 0
 num_arb = 25
 for j in range(num_arb):
-  agents.append(EtfArbAgent(i, "Etf Arb Agent {}".format(i), "EtfArbAgent", portfolio = ['SYM1','SYM2'], gamma = gamma, starting_cash = starting_cash, lambda_a=0.005, log_orders=log_orders, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+  agents.append(EtfArbAgent(i, "Etf Arb Agent {}".format(i), "EtfArbAgent", portfolio = ['SYM1','SYM2'], gamma = gamma, starting_cash = starting_cash, lambda_a=0.005, log_orders=log_orders, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
   agent_types.append("EtfArbAgent {}".format(i))
   i+=1
 agent_count += num_arb
@@ -353,7 +353,7 @@ agent_count += num_arb
 #num_mm = 10
 mm = [(5,0),(5,50),(5,100),(5,200),(5,300)]
 #for j in range(num_mm):
-  #agents.append(EtfMarketMakerAgent(i, "Etf MM Agent {}".format(i), "EtfMarketMakerAgent", portfolio = ['IBM','GOOG'], gamma = gamma, starting_cash = starting_cash, lambda_a=0.005, log_orders=log_orders, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+  #agents.append(EtfMarketMakerAgent(i, "Etf MM Agent {}".format(i), "EtfMarketMakerAgent", portfolio = ['IBM','GOOG'], gamma = gamma, starting_cash = starting_cash, lambda_a=0.005, log_orders=log_orders, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
   #agent_types.append("EtfMarketMakerAgent {}".format(i))
   #i+=1
 #agent_count += num_mm
@@ -361,7 +361,7 @@ mm = [(5,0),(5,50),(5,100),(5,200),(5,300)]
 for i,x in enumerate(mm):
   strat_name = "Type {} [gamma = {}]".format(i+1, x[1])
   print(strat_name)
-  agents.extend([ EtfMarketMakerAgent(j, "Etf MM Agent {} {}".format(j, strat_name), "EtfMarketMakerAgent {}".format(strat_name), portfolio = ['SYM1','SYM2'], gamma = x[1], starting_cash = starting_cash, lambda_a=0.005, log_orders=log_orders, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))) for j in range(agent_count,agent_count+x[0]) ])
+  agents.extend([ EtfMarketMakerAgent(j, "Etf MM Agent {} {}".format(j, strat_name), "EtfMarketMakerAgent {}".format(strat_name), portfolio = ['SYM1','SYM2'], gamma = x[1], starting_cash = starting_cash, lambda_a=0.005, log_orders=log_orders, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))) for j in range(agent_count,agent_count+x[0]) ])
   agent_types.extend([ "EtfMarketMakerAgent {}".format(strat_name) for j in range(x[0]) ])
   agent_count += x[0]
 
@@ -371,18 +371,18 @@ for i,x in enumerate(mm):
 impact_time = midnight + pd.to_timedelta('09:30:00.0000002')
 
 i = agent_count
-agents.append(ImpactAgent(i, "Impact Agent1 {}".format(i), "ImpactAgent1", symbol = "SYM1", starting_cash = starting_cash, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+agents.append(ImpactAgent(i, "Impact Agent1 {}".format(i), "ImpactAgent1", symbol = "SYM1", starting_cash = starting_cash, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
 agent_types.append("ImpactAgent 1 {}".format(i))
 agent_count += 1
 
 impact_time = midnight + pd.to_timedelta('09:30:00.0000005')
 i = agent_count
-agents.append(ImpactAgent(i, "Impact Agent2 {}".format(i), "ImpactAgent2", symbol = "SYM1", starting_cash = starting_cash, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+agents.append(ImpactAgent(i, "Impact Agent2 {}".format(i), "ImpactAgent2", symbol = "SYM1", starting_cash = starting_cash, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
 agent_types.append("ImpactAgent 2 {}".format(i))
 agent_count += 1
 
 #i = agent_count
-#agents.append(ImpactAgent(i, "Impact Agent3 {}".format(i), "ImpactAgent3", symbol = "ETF", starting_cash = starting_cash, greed = greed, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=2**32))))
+#agents.append(ImpactAgent(i, "Impact Agent3 {}".format(i), "ImpactAgent3", symbol = "ETF", starting_cash = starting_cash, greed = greed, impact = impact, impact_time = impact_time, random_state = np.random.RandomState(seed=np.random.randint(low=0,high=np.iinfo(np.int32).max))))
 #agent_types.append("ImpactAgent 3 {}".format(i))
 #agent_count += 1
 

--- a/config/value_noise.py
+++ b/config/value_noise.py
@@ -125,11 +125,11 @@ defaultComputationDelay = 1000000000  # one second
 
 symbols = {'JPM': {'r_bar': 1e5, 'kappa': 1.67e-12, 'agent_kappa': 1.67e-15, 'sigma_s': 0, 'fund_vol': 1e-8,
                    'megashock_lambda_a': 2.77778e-13, 'megashock_mean': 1e3, 'megashock_var': 5e4,
-                   'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64'))}}
+                   'random_state': np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64'))}}
 
 ### Configure the Kernel.
 kernel = Kernel("Base Kernel",
-                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+                random_state=np.random.RandomState(seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
 
 ### Configure the agents.  When conducting "agent of change" experiments, the
 ### new agents should be added at the END only.
@@ -154,7 +154,7 @@ num_exchanges = 1
 agents.extend([ExchangeAgent(j, "Exchange Agent {}".format(j), "ExchangeAgent", mkt_open, mkt_close,
                              [s for s in symbols], log_orders=log_orders, book_freq=book_freq, pipeline_delay=0,
                              computation_delay=0, stream_history=10, random_state=np.random.RandomState(
-        seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')))
+        seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')))
                for j in range(agent_count, agent_count + num_exchanges)])
 agent_types.extend(["ExchangeAgent" for j in range(num_exchanges)])
 agent_count += num_exchanges
@@ -182,7 +182,7 @@ num_noise = 100
 agents.extend( [NoiseAgent(j, "NoiseAgent {}".format(j),
                                          "NoiseAgent",
                                          random_state=np.random.RandomState(
-                                             seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')),
+                                             seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')),
                                          log_orders=log_orders, symbol=symbol, starting_cash=starting_cash,
                                          wakeup_time = mkt_open + np.random.rand() * (mkt_close - mkt_open) ) for j in range(agent_count, agent_count + num_noise )])
 agent_count += num_noise
@@ -197,7 +197,7 @@ num_value = 50
 agents.extend([ValueAgent(j, "Value Agent {}".format(j),
                                          "ValueAgent {}".format(j),
                                          random_state=np.random.RandomState(
-                                             seed=np.random.randint(low=0, high=2 ** 32, dtype='uint64')),
+                                             seed=np.random.randint(low=0, high=np.iinfo(np.int32).max, dtype='uint64')),
                                          log_orders=log_orders, symbol=symbol, #starting_cash=starting_cash,
                                          sigma_n=sigma_n, r_bar=s['r_bar'], kappa=s['agent_kappa'],
                                          sigma_s=s['fund_vol'],

--- a/util/OrderBook.py
+++ b/util/OrderBook.py
@@ -9,7 +9,10 @@ from util.util import log_print, be_silent
 
 from copy import deepcopy
 import pandas as pd
-from pandas.io.json import json_normalize
+try:
+    from pandas import json_normalize
+except ImportError:  # pragma: no cover - fallback for older pandas
+    from pandas.io.json import json_normalize
 from functools import reduce
 from scipy.sparse import dok_matrix
 from tqdm import tqdm

--- a/util/formatting/convert_order_stream.py
+++ b/util/formatting/convert_order_stream.py
@@ -1,6 +1,9 @@
 import argparse
 import pandas as pd
-from pandas.io.json import json_normalize
+try:
+    from pandas import json_normalize
+except ImportError:  # pragma: no cover - fallback for older pandas
+    from pandas.io.json import json_normalize
 import json
 import os
 

--- a/util/simulation_run_stats.py
+++ b/util/simulation_run_stats.py
@@ -1,6 +1,9 @@
 import argparse
 import pandas as pd
-from pandas.io.json import json_normalize
+try:
+    from pandas import json_normalize
+except ImportError:  # pragma: no cover - fallback for older pandas
+    from pandas.io.json import json_normalize
 from glob import glob
 import re
 import os


### PR DESCRIPTION
## Summary
- handle `json_normalize` import for modern pandas
- document running a sample config
- avoid out-of-range randint calls across configs

## Testing
- `pytest -q`
- `python -u abides.py -c rmsc01` *(fails: No module named 'numpy')*
- `pip install -q -r requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684eaf35b1bc83259d65c46e169cd82e