### PR TITLE
Ignore joblib caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ venv/
 .idea/
 .ipynb/
 .ipynb_checkpoints/
+
+**/.cache/


### PR DESCRIPTION
## Summary
- ignore joblib cache directories by matching `**/.cache/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edcd0ac7c8325aa4afde0ed6cdcc9